### PR TITLE
Add curl install

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,11 @@ sudo apt-get install net-tools
 sudo apt-get install make
 ```
 
+### curl
+```console
+sudo apt-get install curl
+```
+
 ## Prysm
 
 ### Create User Accounts


### PR DESCRIPTION
On a brand new 20.04 install I needed to install curl to be able to do the install prysm section.

(thanks for this guide)