### PR TITLE
Extend Prometheus data logging to 31 days

### DIFF
--- a/README.md
+++ b/README.md
@@ -448,6 +448,7 @@ RestartSec=5
 ExecStart=/usr/local/bin/prometheus \
     --config.file /etc/prometheus/prometheus.yml \
     --storage.tsdb.path /var/lib/prometheus/ \
+    --storage.tsdb.retention.time=31d \
     --web.console.templates=/etc/prometheus/consoles \
     --web.console.libraries=/etc/prometheus/console_libraries
 


### PR DESCRIPTION
Prometheus' default data logging time is 15 days. In order for the Grafana dashboard to calculate monthly earnings, we need 31 days of data.